### PR TITLE
refactor: replace stringr::str_replace for base::sub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,7 @@ Depends:
 Imports:
     MASS,
     progressr,
-    reticulate,
-    stringr
+    reticulate
 Suggests: 
     knitr,
     rmarkdown

--- a/R/SeparateInteractions.R
+++ b/R/SeparateInteractions.R
@@ -1,36 +1,34 @@
 make_interaction_data <- function(mod, data, reg_of_interest, separate_interactions) {
   if (!separate_interactions) {
     return(list(data = data, involved = reg_of_interest))
-  } else {
-    if (!mod[["model_specification"]][["regs"]][["interactions"]][["present"]]) {
-      stop("'seperate_interactions' is specified as TRUE, but are no interaction terms present in the model.")
-    }
-
-    if (reg_of_interest %in% mod[["model_specification"]][["regs"]][["metric"]]) {
-      all_int_terms <- mod[["model_specification"]][["regs"]][["interactions"]][["terms"]]
-    } else {
-      all_int_terms <- grep(paste0("\\", notation), names(coef(mod)))
-    }
-
-    terms <- all_int_terms[grep(reg_of_interest, all_int_terms)]
-    notation <- mod[["model_specification"]][["regs"]][["interactions"]][["notation"]]
-
-    INTs <- data.frame(
-      terms = sub(paste0("\\", notation), "_x_", terms),
-      expr = sub(paste0("\\", notation), "*", terms)
-    )
-
-    for (i in seq_along(INTs$terms)) {
-      data[[INTs$terms[i]]] <- with(data, {
-        eval(parse(text = INTs$expr[i]))
-      })
-    }
-
-    involved_regs <- c(INTs$terms, unique(strsplit(terms, paste0("\\", notation))))
-    return(list(data = data, involved = unlist(involved_regs)))
   }
-}
+  if (!mod[["model_specification"]][["regs"]][["interactions"]][["present"]]) {
+    stop("'seperate_interactions' is specified as TRUE, but are no interaction terms present in the model.")
+  }
 
+  if (reg_of_interest %in% mod[["model_specification"]][["regs"]][["metric"]]) {
+    all_int_terms <- mod[["model_specification"]][["regs"]][["interactions"]][["terms"]]
+  } else {
+    all_int_terms <- grep(paste0("\\", notation), names(coef(mod)))
+  }
+
+  terms <- all_int_terms[grep(reg_of_interest, all_int_terms)]
+  notation <- mod[["model_specification"]][["regs"]][["interactions"]][["notation"]]
+
+  INTs <- data.frame(
+    terms = sub(paste0("\\", notation), "_x_", terms),
+    expr = sub(paste0("\\", notation), "*", terms)
+  )
+
+  for (i in seq_along(INTs$terms)) {
+    data[[INTs$terms[i]]] <- with(data, {
+      eval(parse(text = INTs$expr[i]))
+    })
+  }
+
+  involved_regs <- c(INTs$terms, unique(strsplit(terms, paste0("\\", notation))))
+  list(data = data, involved = unlist(involved_regs))
+}
 
 # if (separate_interactions) {
 # if (!mod[["model_specification"]][["regs"]][["interactions"]][["present"]]) {
@@ -40,10 +38,10 @@ make_interaction_data <- function(mod, data, reg_of_interest, separate_interacti
 # terms <- mod[["model_specification"]][["regs"]][["interactions"]][["terms"]]
 # notation <- mod[["model_specification"]][["regs"]][["interactions"]][["notation"]]
 
-#INTs <- data.frame(
+# INTs <- data.frame(
 #  terms = sub(paste0("\\", notation), "_x_", terms),
 #  expr = sub(paste0("\\", notation), "*", terms)
-#)
+# )
 
 # for (i in seq_along(INTs$terms)) {
 #  dat[[INTs$terms[i]]] <- with(dat, {

--- a/R/SeparateInteractions.R
+++ b/R/SeparateInteractions.R
@@ -16,8 +16,8 @@ make_interaction_data <- function(mod, data, reg_of_interest, separate_interacti
     notation <- mod[["model_specification"]][["regs"]][["interactions"]][["notation"]]
 
     INTs <- data.frame(
-      terms = stringr::str_replace(terms, paste0("\\", notation), "_x_"),
-      expr = stringr::str_replace(terms, paste0("\\", notation), "*")
+      terms = sub(paste0("\\", notation), "_x_", terms),
+      expr = sub(paste0("\\", notation), "*", terms)
     )
 
     for (i in seq_along(INTs$terms)) {
@@ -41,8 +41,8 @@ make_interaction_data <- function(mod, data, reg_of_interest, separate_interacti
 #notation <- mod[["model_specification"]][["regs"]][["interactions"]][["notation"]]
 
 #INTs <- data.frame(
-#  terms = stringr::str_replace(terms, paste0("\\", notation), "_x_"),
-#  expr = stringr::str_replace(terms, paste0("\\", notation), "*")
+#  terms = sub(paste0("\\", notation), "_x_", terms),
+#  expr = sub(paste0("\\", notation), "*", terms)
 #)
 
 #for (i in seq_along(INTs$terms)) {

--- a/R/g_theta.R
+++ b/R/g_theta.R
@@ -62,12 +62,12 @@ make_linear_predictor <- function(mod, reg_of_interest = NULL, separate_interact
     TERM <- paste0(model_coefficients[i], " * ", REG, indexing)
     if (separate_interactions && !is.null(reg_of_interest)) {
       if (grepl(reg_of_interest, TERM)) {
-        TERM <- stringr::str_replace(TERM, INT_notation, "_x_")
+        TERM <- sub(INT_notation, "_x_", TERM)
       } else {
-        TERM <- stringr::str_replace(TERM, INT_notation, paste0(indexing, " * "))
+        TERM <- sub(INT_notation, paste0(indexing, " * "), TERM)
       }
     } else {
-      TERM <- stringr::str_replace(TERM, INT_notation, paste0(indexing, " * "))
+      TERM <- sub(INT_notation, paste0(indexing, " * "), TERM)
     }
     model_terms[[j]] <- list(
       model_term = TERM,


### PR DESCRIPTION
Somewhat opinionated, but seems worth it for removing the stringr dependency since only used for `stringr::str_replace()` equivalent to `base::sub()` 